### PR TITLE
Disable require of deprecated sys

### DIFF
--- a/mojoloader.js
+++ b/mojoloader.js
@@ -350,7 +350,7 @@ if (typeof MojoLoader === 'undefined')
 			else if (typeof require !== "undefined")
 			{
 				var webOS = require('webos');
-				var sys = require('sys');
+				//var sys = require('sys');
 				function nodeRequire (loader, filesArary) {
 				    return webOS.require(require, loader, filesArary);
 				}


### PR DESCRIPTION
Solves: Oct 03 11:19:52 qemux86 ls-hubd[473]: (node) sys is deprecated. Use util instead.

The sys reference is not used anyway it seems, so we could have just as well deleted it completely from the code, but will leave it here for now, just disabled.

Signed-off-by: Herman van Hazendonk github.com@herrie.org
